### PR TITLE
Bump -  add support for bumonly flag

### DIFF
--- a/lib/gitHelper.js
+++ b/lib/gitHelper.js
@@ -13,15 +13,17 @@ const getCurrentBranch = async function () {
     return branches.current;
 };
 
-const commitVersion = async function (version, production, files, hotfix = false) {
+const commitVersion = async function (version, production, files, hotfix = false, bumponly = false) {
     const commitMessage = `chore(app): Version ${version} ${production ? ' production' : ''} `;
     try {
         const currentBranch = hotfix ? await getCurrentBranch() : 'master';
         await git.add(files);
         await git.commit(commitMessage);
-        await git.addAnnotatedTag(version, 'v' + version);
-        await git.push('origin', currentBranch);
-        await git.pushTags('origin');
+        if (!bumponly) {
+            await git.addAnnotatedTag(version, 'v' + version);
+            await git.push('origin', currentBranch);
+            await git.pushTags('origin');
+        }
     } catch (e) {
         throw new Error(e);
     }


### PR DESCRIPTION
This will allow to just bump the packages and commit without pushing or creating a tag