### PR TITLE
Hotfix - add support to push hotfix tag

### DIFF
--- a/lib/gitHelper.js
+++ b/lib/gitHelper.js
@@ -19,7 +19,7 @@ const commitVersion = async function (version, production, files, hotfix = false
         const currentBranch = hotfix ? await getCurrentBranch() : 'master';
         await git.add(files);
         await git.commit(commitMessage);
-        await git.addAnnotatedTag(version, 'v' + version);
+        await git.addAnnotatedTag(`${version}${hotfix ? '-hf' : ''}`, `v${version}${hotfix ? '-hf' : ''}`);
         await git.push('origin', currentBranch);
         await git.pushTags('origin');
     } catch (e) {


### PR DESCRIPTION
Hotfix branches will now have `hf` appended to the branch name